### PR TITLE
Fix stockfish suggesting terrible moves.

### DIFF
--- a/src/backend/cppCore/cppCore.vcxproj
+++ b/src/backend/cppCore/cppCore.vcxproj
@@ -129,12 +129,14 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="processLauncher.cpp" />
     <ClCompile Include="stockfishHandler.cpp" />
+    <ClCompile Include="stockfishProcess.cpp" />
     <ClCompile Include="utilities.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="httpServerHandler.h" />
     <ClInclude Include="processLauncher.h" />
     <ClInclude Include="stockfishHandler.h" />
+    <ClInclude Include="stockfishProcess.h" />
     <ClInclude Include="utilitites.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/backend/cppCore/cppCore.vcxproj.filters
+++ b/src/backend/cppCore/cppCore.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="utilities.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="stockfishProcess.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="processLauncher.h">
@@ -42,6 +45,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="utilitites.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stockfishProcess.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/backend/cppCore/processLauncher.cpp
+++ b/src/backend/cppCore/processLauncher.cpp
@@ -5,12 +5,8 @@
 
 
 void ProcessLauncher::LaunchEngines() {
-    std::wstring stockfishPath = L"C:\\stockfish\\stockfish-windows-x86-64-avx2.exe";
     std::wstring ollamaPath = GetOllamaPath();
 
-    if (!LaunchProcess(stockfishPath)) {
-        std::wcerr << L"Failed to launch Stockfish." << std::endl;
-    }
     if (!LaunchProcess(ollamaPath)) {
         std::wcerr << L"Failed to launch Ollama." << std::endl;
     }

--- a/src/backend/cppCore/stockfishProcess.cpp
+++ b/src/backend/cppCore/stockfishProcess.cpp
@@ -1,0 +1,126 @@
+#include "StockfishProcess.h"
+#include <windows.h>
+#include <string>
+#include <mutex>
+#include <vector>
+#include <iostream>
+
+StockfishProcess::StockfishProcess(const std::string& stockfishPath)
+    : hProcess_(NULL), hThread_(NULL), hChildStdinWr_(NULL), hChildStdoutRd_(NULL) {
+    startProcess(stockfishPath);
+    // Send "uci" and wait for "uciok"
+    std::string dummy;
+    sendCommand("uci\n");
+    readUntil("uciok", dummy);
+}
+
+StockfishProcess::~StockfishProcess() {
+    stopProcess();
+}
+
+bool StockfishProcess::startProcess(const std::string& stockfishPath) {
+    SECURITY_ATTRIBUTES saAttr{};
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+    saAttr.lpSecurityDescriptor = NULL;
+
+    HANDLE hChildStdinRd = NULL;
+    HANDLE hChildStdoutWr = NULL;
+
+    // Create pipes for STDIN and STDOUT
+    if (!CreatePipe(&hChildStdoutRd_, &hChildStdoutWr, &saAttr, 0)) return false;
+    if (!SetHandleInformation(hChildStdoutRd_, HANDLE_FLAG_INHERIT, 0)) return false;
+    if (!CreatePipe(&hChildStdinRd, &hChildStdinWr_, &saAttr, 0)) return false;
+    if (!SetHandleInformation(hChildStdinWr_, HANDLE_FLAG_INHERIT, 0)) return false;
+
+    PROCESS_INFORMATION piProcInfo{};
+    STARTUPINFOA siStartInfo{};
+    siStartInfo.cb = sizeof(STARTUPINFOA);
+    siStartInfo.hStdError = hChildStdoutWr;
+    siStartInfo.hStdOutput = hChildStdoutWr;
+    siStartInfo.hStdInput = hChildStdinRd;
+    siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+
+    std::string cmdLine = "\"" + stockfishPath + "\"";
+    BOOL bSuccess = CreateProcessA(
+        NULL,
+        &cmdLine[0],
+        NULL,
+        NULL,
+        TRUE,
+        0,
+        NULL,
+        NULL,
+        &siStartInfo,
+        &piProcInfo
+    );
+
+    // Close handles we don't need
+    CloseHandle(hChildStdoutWr);
+    CloseHandle(hChildStdinRd);
+
+    if (!bSuccess) return false;
+
+    hProcess_ = piProcInfo.hProcess;
+    hThread_ = piProcInfo.hThread;
+    return true;
+}
+
+void StockfishProcess::stopProcess() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (hProcess_) {
+        TerminateProcess(hProcess_, 0);
+        CloseHandle(hProcess_);
+        hProcess_ = NULL;
+    }
+    if (hThread_) {
+        CloseHandle(hThread_);
+        hThread_ = NULL;
+    }
+    if (hChildStdinWr_) {
+        CloseHandle(hChildStdinWr_);
+        hChildStdinWr_ = NULL;
+    }
+    if (hChildStdoutRd_) {
+        CloseHandle(hChildStdoutRd_);
+        hChildStdoutRd_ = NULL;
+    }
+}
+
+bool StockfishProcess::sendCommand(const std::string& command) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (!hChildStdinWr_) return false;
+    DWORD written = 0;
+    BOOL bSuccess = WriteFile(hChildStdinWr_, command.c_str(), (DWORD)command.size(), &written, NULL);
+    return bSuccess && written == command.size();
+}
+
+bool StockfishProcess::readUntil(const std::string& waitFor, std::string& resultLine) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (!hChildStdoutRd_) return false;
+    std::string buffer;
+    char chBuf[256];
+    DWORD dwRead;
+    while (true) {
+        BOOL bSuccess = ReadFile(hChildStdoutRd_, chBuf, sizeof(chBuf) - 1, &dwRead, NULL);
+        if (!bSuccess || dwRead == 0) break;
+        chBuf[dwRead] = '\0';
+        buffer += chBuf;
+        size_t pos = buffer.find('\n');
+        while (pos != std::string::npos) {
+            std::string line = buffer.substr(0, pos);
+            if (line.find(waitFor) != std::string::npos) {
+                resultLine = line;
+                return true;
+            }
+            buffer = buffer.substr(pos + 1);
+            pos = buffer.find('\n');
+        }
+    }
+    return false;
+}
+
+bool StockfishProcess::sendCommandAndWait(const std::string& command, const std::string& waitFor, std::string& resultLine) {
+    if (!sendCommand(command)) return false;
+    return readUntil(waitFor, resultLine);
+}

--- a/src/backend/cppCore/stockfishProcess.h
+++ b/src/backend/cppCore/stockfishProcess.h
@@ -1,0 +1,74 @@
+#pragma once
+#include <string>
+#include <mutex>
+#include <windows.h>
+
+/**
+ * @brief Manages a persistent Stockfish engine process with bidirectional pipes (Windows only).
+ *
+ * This class launches Stockfish as a child process and communicates with it
+ * via stdin/stdout pipes. It is thread-safe and allows sending UCI commands
+ * and reading responses. The process is started once and only closed on destruction.
+ *
+ * Usage:
+ *   StockfishProcess stockfish("C:\\path\\to\\stockfish.exe");
+ *   stockfish.sendCommand("uci\n");
+ *   std::string line;
+ *   stockfish.readUntil("uciok", line);
+ */
+class StockfishProcess {
+public:
+    /**
+     * @brief Constructs and launches the Stockfish process.
+     * @param stockfishPath Path to the Stockfish executable.
+     */
+    explicit StockfishProcess(const std::string& stockfishPath);
+
+    /**
+     * @brief Destructor. Terminates the Stockfish process and closes all handles.
+     */
+    ~StockfishProcess();
+
+    /**
+     * @brief Sends a UCI command to Stockfish and reads output until a line containing the given keyword.
+     * @param command The command to send (e.g. "position fen ...").
+     * @param waitFor The keyword to wait for in output (e.g. "bestmove").
+     * @param resultLine The line containing the keyword will be stored here.
+     * @return true on success, false on error.
+     */
+    bool sendCommandAndWait(const std::string& command, const std::string& waitFor, std::string& resultLine);
+
+    /**
+     * @brief Sends a command to Stockfish.
+     * @param command The command to send.
+     * @return true on success.
+     */
+    bool sendCommand(const std::string& command);
+
+    /**
+     * @brief Reads lines from Stockfish until a line containing the given keyword.
+     * @param waitFor The keyword to wait for.
+     * @param resultLine The line containing the keyword will be stored here.
+     * @return true if found, false otherwise.
+     */
+    bool readUntil(const std::string& waitFor, std::string& resultLine);
+
+private:
+    HANDLE hProcess_;         ///< Handle to the Stockfish process.
+    HANDLE hThread_;          ///< Handle to the Stockfish main thread.
+    HANDLE hChildStdinWr_;    ///< Write handle to Stockfish's stdin.
+    HANDLE hChildStdoutRd_;   ///< Read handle from Stockfish's stdout.
+    std::mutex mtx_;          ///< Mutex for thread safety.
+
+    /**
+     * @brief Starts the Stockfish process and sets up pipes.
+     * @param stockfishPath Path to the Stockfish executable.
+     * @return true on success, false on failure.
+     */
+    bool startProcess(const std::string& stockfishPath);
+
+    /**
+     * @brief Terminates the Stockfish process and closes all handles.
+     */
+    void stopProcess();
+};


### PR DESCRIPTION
Fix stockfish suggesting terrible moves by making it running as a child process. As a result, remove Stockfish from the initial processLauncher.